### PR TITLE
Add compatibility to python 3.8

### DIFF
--- a/src/pytraits/core/composing/compiler.py
+++ b/src/pytraits/core/composing/compiler.py
@@ -40,7 +40,7 @@ class Compiler:
 
         trait["co_argcount"] = function.__code__.co_argcount
         trait["co_kwonlyargcount"] = function.__code__.co_kwonlyargcount
-        if sys.version_info[0] == 3 and sys.version_info[1] >= 8:
+        if sys.version_info[:1] >= (3, 8) :
           trait["co_posonlyargcount"] = function.__code__.co_posonlyargcount
         trait["co_nlocals"] = function.__code__.co_nlocals
         trait["co_stacksize"] = function.__code__.co_stacksize

--- a/src/pytraits/core/composing/compiler.py
+++ b/src/pytraits/core/composing/compiler.py
@@ -40,7 +40,7 @@ class Compiler:
 
         trait["co_argcount"] = function.__code__.co_argcount
         trait["co_kwonlyargcount"] = function.__code__.co_kwonlyargcount
-        if sys.version_info[:1] >= (3, 8) :
+        if sys.version_info[:2] >= (3, 8) :
           trait["co_posonlyargcount"] = function.__code__.co_posonlyargcount
         trait["co_nlocals"] = function.__code__.co_nlocals
         trait["co_stacksize"] = function.__code__.co_stacksize

--- a/src/pytraits/core/composing/compiler.py
+++ b/src/pytraits/core/composing/compiler.py
@@ -39,6 +39,7 @@ class Compiler:
 
         trait["co_argcount"] = function.__code__.co_argcount
         trait["co_kwonlyargcount"] = function.__code__.co_kwonlyargcount
+        trait["co_posonlyargcount"] = function.__code__.co_posonlyargcount
         trait["co_nlocals"] = function.__code__.co_nlocals
         trait["co_stacksize"] = function.__code__.co_stacksize
         trait["co_flags"] = function.__code__.co_flags

--- a/src/pytraits/core/composing/compiler.py
+++ b/src/pytraits/core/composing/compiler.py
@@ -18,6 +18,7 @@
 
 import types
 import collections
+import sys
 
 from pytraits.support import is_sysname
 from pytraits.core import TraitFactory
@@ -39,7 +40,8 @@ class Compiler:
 
         trait["co_argcount"] = function.__code__.co_argcount
         trait["co_kwonlyargcount"] = function.__code__.co_kwonlyargcount
-        trait["co_posonlyargcount"] = function.__code__.co_posonlyargcount
+        if sys.version_info[0] == 3 and sys.version_info[1] >= 8:
+          trait["co_posonlyargcount"] = function.__code__.co_posonlyargcount
         trait["co_nlocals"] = function.__code__.co_nlocals
         trait["co_stacksize"] = function.__code__.co_stacksize
         trait["co_flags"] = function.__code__.co_flags


### PR DESCRIPTION
py3traits stops working for python 3.8. With the change proposed in this PR py3traits works for 3.8 again.